### PR TITLE
feat(git-worktree) add persistence of path to wtcd command

### DIFF
--- a/plugins/git-worktree/README.md
+++ b/plugins/git-worktree/README.md
@@ -7,13 +7,13 @@ A plugin for working with git worktrees.
 ### `GIT_WORKTREE_DIR`
 
 If defined, new worktrees will be added in this folder.
-If not defined, new trees will be added one level up from the git root, aka next to your original clone folder.
+If not defined, new trees will be added one level up from the git root, aka next to your original clone folder. This is useful if you check out the main branch in a subfolder of your project dir.
 
 ## Commands
 
 ### wtcd
 
-Change dir to worktree folder based on branch name. Supports TAB completion of branches.
+Change dir to worktree folder based on branch name. Supports `TAB` completion of branches. The current path within the worktree will be retained if it exists on the destination tree. If not, the command will fall back to root.
 
 ```shell
 wtcd main

--- a/plugins/git-worktree/git-worktree.plugin.zsh
+++ b/plugins/git-worktree/git-worktree.plugin.zsh
@@ -29,7 +29,14 @@ function wtcd() {
         return 1
     fi
 
-    cd $worktree_path
+    # Get the relative path of the current worktree.
+    local relative_path=$(realpath --relative-to=$(git rev-parse --show-toplevel) $PWD)
+    if [[ ! -d $worktree_path/$relative_path ]]; then
+        echo "The current directory (${relative_path}) is not in the worktree, changing to worktree root."
+        cd $worktree_path
+    else
+        cd $worktree_path/$relative_path
+    fi
 }
 
 # List Worktrees


### PR DESCRIPTION
This will keep the current path when switching worktree.

Fix for #2 